### PR TITLE
Fix doctest + add quickcheck properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add `:libring` to your deps, and run `mix deps.get`.
 
 ```elixir
 def deps do
-  [{:libring, "~> 1.1"}]
+  [{:libring, "~> 1.0"}]
 end
 ```
 

--- a/lib/managed_ring.ex
+++ b/lib/managed_ring.ex
@@ -55,10 +55,10 @@ defmodule HashRing.Managed do
       ...> HashRing.Managed.key_to_node(:test1, :foo)
       "b"
 
-      iex> {:ok, _pid} = HashRing.Managed.new(:test2)
-      ...> HashRing.Managed.new(:test2)
-      {:error, :already_exists}
-
+      iex> {:ok, pid} = HashRing.Managed.new(:test2)
+      ...> {:error, {:already_started, existing_pid}} = HashRing.Managed.new(:test2)
+      ...> pid == existing_pid
+      true
       iex> HashRing.Managed.new(:test3, [nodes: "a"])
       {:error, {:invalid_option, {:nodes, "a"}}}
   """

--- a/lib/ring.ex
+++ b/lib/ring.ex
@@ -93,7 +93,7 @@ defmodule HashRing do
   @spec add_node(__MODULE__.t, term(), pos_integer) :: __MODULE__.t
   def add_node(ring, node, weight \\ 128)
   def add_node(_, node, _weight) when is_binary(node) and byte_size(node) == 0,
-    do: raise ArgumentError, message: "Node name needs to be longer than 0"
+    do: raise ArgumentError, message: "Node keys cannot be empty strings"
   def add_node(%__MODULE__{} = ring, node, weight) when is_integer(weight) and weight > 0 do
     cond do
       Enum.member?(ring.nodes, node) ->

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule HashRing.Mixfile do
 
   def project do
     [app: :libring,
-     version: "1.0.1",
+     version: "1.0.2",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HashRing.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "A fast consistent hash ring implementation in Elixir",
-     package: package,
+     package: package(),
      docs: docs(),
      deps: deps(),
      dialyzer: [


### PR DESCRIPTION
This escalated quickly - I added 3 simple QuickCheck properties that at least discovered a small bug:
One could create a new node with an empty name, but never delete it from a HashRing again.

This also fixes a failing doctest that I had to get out of the way.