### PR TITLE
Fix the whitelist to handle multiple patterns

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -39,7 +39,7 @@ defmodule HashRing.Utils do
     end)
   end
   def ignore_node?(node, [], whitelist) when is_binary(node) and is_list(whitelist) do
-    Enum.any?(whitelist, fn
+    Enum.all?(whitelist, fn
       ^node ->
         false
       %Regex{} = pattern ->


### PR DESCRIPTION
Right now the whitelist doesn't work on multiple patterns because the function at line 42 will only return false on the pattern it matches, but will then return true on the other patterns. Not sure if Enum.all? is the most performant fix, but it should fix the bug.