### PR TITLE
Added missing dependency :logger application dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule HashRing.Mixfile do
   end
 
   def application do
-    [applications: [:crypto],
+    [applications: [:logger, :crypto],
      mod: {HashRing.App, []}]
   end
 


### PR DESCRIPTION
In some cases :libring was started before :logger causing errors like:


```
=INFO REPORT==== 15-Oct-2018::21:41:03 ===
    application: libring
    exited: {bad_return,
                {{'Elixir.HashRing.App',start,[normal,[]]},
                 {'EXIT',
                     {#{'__exception__' => true,
                        '__struct__' => 'Elixir.RuntimeError',
                        message =>
                            <<"cannot use Logger, the :logger application is not running">>},
                      [{'Elixir.Logger.Config','__data__',0,
                           [{file,"lib/logger/config.ex"},{line,53}]},
```