### PR TITLE
Empty names work, so can safely be allowed.

### DIFF
--- a/lib/ring.ex
+++ b/lib/ring.ex
@@ -92,8 +92,7 @@ defmodule HashRing do
   """
   @spec add_node(__MODULE__.t, term(), pos_integer) :: __MODULE__.t
   def add_node(ring, node, weight \\ 128)
-  def add_node(_, node, _weight) when is_binary(node) and byte_size(node) == 0,
-    do: raise ArgumentError, message: "Node keys cannot be empty strings"
+
   def add_node(%__MODULE__{} = ring, node, weight) when is_integer(weight) and weight > 0 do
     cond do
       Enum.member?(ring.nodes, node) ->

--- a/test/hashring_test.exs
+++ b/test/hashring_test.exs
@@ -6,12 +6,6 @@ defmodule HashRingTest do
 
   def string, do: utf8()
 
-  test "binary names without a length are rejected" do
-    assert_raise ArgumentError, fn ->
-      HashRing.new("")
-    end
-  end
-
   test "key_to_nodes/3 uses node length if the count is greater than node length" do
     nodes =
     HashRing.new()


### PR DESCRIPTION
I'm going to use this in Horde, but when I pulled it in and added my code and ran my tests (property tests), they crashed on node name `""`.

I went digging, and there was a PR (#7) that claimed that empty strings broke removing a node. There must have been a fix in that PR for that very same issue (or it was fixed later?) because adding and removing a node with name `""` appears to work fine now.

So I removed the test and the function that rejected `""` as a node name.