### PR TITLE
Replace :simple_one_for_one with DynamicSupervisor

### DIFF
--- a/lib/managed_ring.ex
+++ b/lib/managed_ring.ex
@@ -81,7 +81,7 @@ defmodule HashRing.Managed do
       nil ->
         case Process.whereis(:"libring_#{name}") do
           nil ->
-            Supervisor.start_child(HashRing.Supervisor, [opts])
+            DynamicSupervisor.start_child(HashRing.Supervisor, {HashRing.Worker, opts})
           pid ->
             {:error, {:already_started, pid}}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule HashRing.Mixfile do
     [
       app: :libring,
       version: "1.4.0",
-      elixir: "~> 1.3",
+      elixir: "~> 1.6",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description: "A fast consistent hash ring implementation in Elixir",


### PR DESCRIPTION
Using `:simple_one_for_one` with `Supervisor` is deprecated in Elixir 1.10 as it has been superseded by `DynamicSupervisor`. 

I think I've done this correctly. At least the tests pass and there aren't any issues when using it in our codebase.

Fixes #20 