### PR TITLE
Update to DynamicSupervisor

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -4,13 +4,8 @@ defmodule HashRing.App do
   require Logger
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     # Start the ring supervisor
-    children = [
-      worker(HashRing.Worker, [], restart: :transient)
-    ]
-    {:ok, pid} = Supervisor.start_link(children, strategy: :simple_one_for_one, name: HashRing.Supervisor)
+    {:ok, pid} = DynamicSupervisor.start_link(__MODULE__, nil, name: HashRing.Supervisor)
 
     # Add any preconfigured rings
     Enum.each(Application.get_env(:libring, :rings, []), fn
@@ -24,5 +19,9 @@ defmodule HashRing.App do
 
     # Application started
     {:ok, pid}
+  end
+
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/lib/managed_ring.ex
+++ b/lib/managed_ring.ex
@@ -81,7 +81,8 @@ defmodule HashRing.Managed do
       nil ->
         case Process.whereis(:"libring_#{name}") do
           nil ->
-            Supervisor.start_child(HashRing.Supervisor, [opts])
+            spec = {HashRing.Worker, opts}
+            DynamicSupervisor.start_child(HashRing.Supervisor, spec)
           pid ->
             {:error, {:already_started, pid}}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule HashRing.Mixfile do
     [
       app: :libring,
       version: "1.4.0",
-      elixir: "~> 1.3",
+      elixir: "~> 1.6",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description: "A fast consistent hash ring implementation in Elixir",


### PR DESCRIPTION
The `:simple_one_for_one` supervisor has been deprecated in favour of `DynamicSupervisor`. This change makes that replacement to fix the deprecation warning at startup.

This move does require upping the minimum Elixir version to 1.6, but that's already over two years old at this point so I'd hope anyone actively updating this library has probably long since moved to it.

Unfortunately I don't have access to quickcheck, so I couldn't run the test suite. Apologies if this change breaks anything in there.