### PR TITLE
Support node_type option to avoid monitoring hidden node

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ config :libring,
     # A ring which automatically changes based on Erlang cluster membership,
     # but does not allow nodes named "a" or "remsh*" to be added to the ring
     ring_a: [monitor_nodes: true,
+             node_type: :visible,
              node_blacklist: ["a", ~r/^remsh.*$/]],
     # A ring which is composed of three nodes, of which "c" has a non-default weight of 200
     # The default weight is 128

--- a/lib/managed_ring.ex
+++ b/lib/managed_ring.ex
@@ -28,7 +28,7 @@ defmodule HashRing.Managed do
     node_blacklist: pattern_list,
     node_whitelist: pattern_list]
 
-  @valid_ring_opts [:name, :nodes, :monitor_nodes, :node_blacklist, :node_whitelist]
+  @valid_ring_opts [:name, :nodes, :monitor_nodes, :node_blacklist, :node_whitelist, :node_type]
 
   @doc """
   Creates a new stateful hash ring with the given name.
@@ -46,6 +46,8 @@ defmodule HashRing.Managed do
     is provided, the blacklist has no effect.
   - `node_whitelist: [String.t | Regex.t]`: The same as `node_blacklist`, except the opposite; only nodes
     which match a pattern in the whitelist will result in the ring being updated.
+  - `node_type: :all | :hidden | :visible`: refers what kind of nodes will be monitored
+    when `monitor_nodes` is `true`. For more information, see `:net_kernel.monitor_nodes/2`.
 
   An error is returned if the ring already exists or if bad ring options are provided.
 
@@ -74,6 +76,7 @@ defmodule HashRing.Managed do
           :monitor_nodes when is_boolean(value) -> false
           :node_blacklist when is_list(value) -> false
           :node_whitelist when is_list(value) -> false
+          :node_type when value in [:all, :hidden, :visible] -> false
           _ -> true
         end
     end)

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -39,7 +39,8 @@ defmodule HashRing.Worker do
               HashRing.add_node(acc, node)
           end
         end)
-        :ok = :net_kernel.monitor_nodes(true, [node_type: :all])
+        node_type = Keyword.get(options, :node_type, :all)
+        :ok = :net_kernel.monitor_nodes(true, [node_type: node_type])
         {:ok, {ring, node_blacklist, node_whitelist}}
       :else ->
         nodes = Keyword.get(options, :nodes, [])

--- a/test/hashring_worker_test.exs
+++ b/test/hashring_worker_test.exs
@@ -1,0 +1,36 @@
+defmodule HashRing.WorkerTest do
+  use ExUnit.Case
+
+  describe "when the given node_type is :visible" do
+    setup do
+      TestCluster.prepare()
+
+      {:ok, pid} =
+        HashRing.Worker.start_link(
+          name: :test_ring_worker,
+          monitor_nodes: true,
+          node_type: :visible
+        )
+
+      on_exit(fn ->
+        HashRing.Worker.delete(pid)
+        TestCluster.teardown()
+      end)
+
+      %{worker: pid}
+    end
+
+    test "it monitors only visible nodes", %{worker: pid} do
+      nodes = [Node.self()]
+      assert nodes == HashRing.Worker.nodes(pid)
+
+      {:ok, node1} = TestCluster.start_node('test_node1')
+
+      nodes = [node1 | nodes]
+      assert nodes == HashRing.Worker.nodes(pid)
+
+      {:ok, _node2} = TestCluster.start_node('test_node2', :hidden)
+      assert nodes == HashRing.Worker.nodes(pid)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,27 @@
+defmodule TestCluster do
+  def start_node(name) do
+    :slave.start_link(:localhost, name)
+  end
+
+  def start_node(name, :hidden) do
+    :slave.start_link(:localhost, name, '-hidden')
+  end
+
+  def stop_node(node) do
+    :slave.stop(node)
+  end
+
+  def prepare do
+    :ok = :net_kernel.monitor_nodes(true)
+
+    _ = :os.cmd('epmd -daemon')
+
+    {:ok, _} = Node.start(:test_cluster@localhost, :shortnames)
+  end
+
+  def teardown do
+    :ok = Node.stop()
+  end
+end
+
 ExUnit.start()


### PR DESCRIPTION
## What I did
This PR adds `node_type` option used in `:net_kernel.monitor_nodes/2`.
`HashRing.Worker` will not monitor the hidden nodes when the given `node_type` is `:visible`.
In addition, it keeps the current behavior.

## Note for the test
I require to use https://github.com/Quviq/eqc_ex/pull/11 to install the test tool.
```elixir
{:eqc_ex, git: "https://github.com/tony612/eqc_ex", branch: "fix-elixir-1-10", only: [:test]}
```

To install it.
```console
env MIX_ENV=test mix eqc.install --mini
```

## Background
We have developed an Elixir application which uses libring to distribute worker process on the nodes.
We can attach the running Elixir application which is deployed to some environments (e.g., development, staging, and production)  using `bin/my_application remote` command.

I noticed some worker processes try to work on my remote shell during debugging.
Usually, remote shell connects the cluster as hidden node.
I also expected that the hidden nodes are ignored.
I figured out libring monitor all nodes connected to the cluster after investigation.

Next, I found that libring has `node_backlist` option and the default value is ` [~r/^remsh.*$/]`.
I had thought remote shell was ignored.
But the node name is `rem-4e08-my-application@11.22.333.444`. (it's just an example.)
So, it's prefixed by `rem`, not `remsh`!

I dived into the Elixir code and found this line.
```sh
             $(release_distribution "rem-$(rand)-$RELEASE_NODE") \
```
https://github.com/elixir-lang/elixir/blob/1145dc01680aab7094f8a6dbd38b65185e14adb4/lib/mix/lib/mix/tasks/release.init.ex#L199
It appends `rem` prefix to the remote shell name.
Furthermore, I found `bin/my_application rpc` appends `rpc` prefix to the name.

Of course, we can add them to the default value of the `node_blacklist` option.
But the prefix is Elixir internally things. So we should not depend on them.
Actually the prefixes were changed in the past. You can see those in the past commits.

[Erlang/OTP document about hidden node](http://erlang.org/doc/reference_manual/distributed.html#hidden-nodes) says 
> An example is some kind of O&M functionality used to inspect the status of a system, without disturbing it. For this purpose, a hidden node can be used.

So, the hidden nodes should not be used in normal applications.

I created this PR for those reasons.

Best regards,