### PR TITLE
fix: replace deprecated Logger.warn

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -39,7 +39,7 @@ defmodule HashRing.Utils do
 
           {:error, reason} ->
             :ok =
-              Logger.warn(
+              Logger.warning(
                 "[libring] ignore_node?/3: invalid blacklist pattern (#{inspect(pattern)}): #{inspect(reason)}"
               )
 
@@ -63,7 +63,7 @@ defmodule HashRing.Utils do
 
           {:error, reason} ->
             :ok =
-              Logger.warn(
+              Logger.warning(
                 "[libring] ignore_node?/3: invalid whitelist pattern (#{inspect(pattern)}): #{inspect(reason)}"
               )
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HashRing.Mixfile do
     [
       app: :libring,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: "A fast consistent hash ring implementation in Elixir",


### PR DESCRIPTION
Pulls in @MikaAK's commit from https://github.com/bitwalker/libring/pull/32 and also updates elixir to 1.11 to get access to `Logger.warning`. Fixes warnings in downstream libraries—thank you!