### PR TITLE
Fix build errors, use :gb_trees.next instead of matching on opaque type.

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -12,7 +12,7 @@ defmodule HashRing.App do
       start: {HashRing.Worker, :start_link, [[restart: :transient, name: HashRing.Worker]]}
     }
 
-    DynamicSupervisor.start_child(HashRing.Supervisor, spec)
+    _ = DynamicSupervisor.start_child(HashRing.Supervisor, spec)
 
     # Add any preconfigured rings
     Enum.each(Application.get_env(:libring, :rings, []), fn

--- a/lib/ring.ex
+++ b/lib/ring.ex
@@ -205,8 +205,8 @@ defmodule HashRing do
   def key_to_node(%__MODULE__{ring: r}, key) do
     hash = :erlang.phash2(key, @hash_range)
 
-    case :gb_trees.iterator_from(hash, r) do
-      [{_key, node, _, _} | _] ->
+    case :gb_trees.iterator_from(hash, r) |> :gb_trees.next() do
+      {_key, node, _} ->
         node
 
       _ ->
@@ -244,8 +244,8 @@ defmodule HashRing do
     hash = :erlang.phash2(key, @hash_range)
     count = min(length(nodes), count)
 
-    case :gb_trees.iterator_from(hash, r) do
-      [{_key, node, _, _} | _] = iter ->
+    case :gb_trees.iterator_from(hash, r) |> :gb_trees.next() do
+      {_key, node, iter} ->
         find_nodes_from_iter(iter, count - 1, [node])
 
       _ ->
@@ -262,7 +262,6 @@ defmodule HashRing do
         if node in results do
           find_nodes_from_iter(iter, count, results)
         else
-          [node | results]
           find_nodes_from_iter(iter, count - 1, [node | results])
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule HashRing.Mixfile do
       docs: docs(),
       deps: deps(),
       dialyzer: [
-        flags: ~w(-Wunmatched_returns -Werror_handling -Wrace_conditions -Wno_opaque -Wunderspecs)
+        flags: ~w(-Wunmatched_returns -Werror_handling -Wno_opaque -Wunderspecs)
       ],
       preferred_cli_env: [
         docs: :docs,


### PR DESCRIPTION
The managed_ring.ex file had errors in the child_spec function and its spec.

The spec for child_spec_options has syntax errors.  It started off indicating list, but then used map syntax for the items.
It was also attempting to call Keyword.merge but passing in a map instead of a keyword list.

The ring.ex file does pattern matching on an opaque type.  Instead it should use :gb_trees.next() to extract out the data from the opaque type.

