### PR TITLE
fix: use correct starting function for child_spec/1

### DIFF
--- a/lib/managed_ring.ex
+++ b/lib/managed_ring.ex
@@ -56,7 +56,7 @@ defmodule HashRing.Managed do
         id: opts[:id] || opts[:name],
         type: :worker,
         restart: :permanent,
-        start: {__MODULE__, :run, [opts[:name], Keyword.take(opts, @valid_ring_opts)]}
+        start: {__MODULE__, :new, [opts[:name], Keyword.take(opts, @valid_ring_opts)]}
       },
       Map.new(Keyword.drop(opts, @valid_ring_opts))
     )

--- a/test/hashring_managed_test.exs
+++ b/test/hashring_managed_test.exs
@@ -1,4 +1,11 @@
 defmodule HashRing.ManagedTest do
   use ExUnit.Case, async: true
   doctest HashRing.Managed
+
+  describe "child_spec" do
+    test "starts a ring", ctx do
+      name = String.to_atom("#{ctx.module}#{ctx.test}")
+      assert {:ok, _pid} = start_supervised({HashRing.Managed, [name: name]})
+    end
+  end
 end


### PR DESCRIPTION
### Summary of changes

Previously, the `child_spec/1` function referenced a non-existent run function. This would mean that a child spec such as:

    {HashRing.Managed, [name: :foo]}

Would not work, instead requiring the start function to be explicitly specified:

    {HashRing.Managed, [name: :foo, start: {HashRing.Managed, :new, [:foo, []]}]}

This commit uses the `new/2` function instead.

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit

---

- [ ] Notes added to CHANGELOG file which describe changes at a high-level

There is no changelog?
